### PR TITLE
fix: make web_accessable_resouces more permissive

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -25,8 +25,7 @@
 
   "web_accessible_resources": [
     "public/*",
-    "dist/scraper.js",
-    "dist/scraper.js.map"
+    "dist/*"
   ],
 
   "browser_action": {


### PR DESCRIPTION
The plugin was trying to access a file not listed in "web_accessable_resources" and crashing.
Everything in dist should be provided by the plugin so using a wildcard eases the maintainance
burden.

fixes #92